### PR TITLE
Add some help for building with scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/forms/*

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+declare DIR="$(cd "$(dirname "$0")/" && pwd -P)"
+
+mkdir -p "${DIR}/src/forms"
+rm -f "${DIR}/src/forms/"*.py
+
+for filename in "${DIR}/designer/"*'.ui'; do
+  pyuic5 "$filename" > "${DIR}/src/forms/$(basename ${filename%.*}).py"
+done


### PR DESCRIPTION
This adds a gitignore with src/forms and a build script for quickly refreshing the built files.
The script works on both Linux and Mac. It is safe to execute from anywhere within the system ($DIR expands to the directory "build.sh" is in).