### PR TITLE
Allow for escape sequences in text wrappers

### DIFF
--- a/src/editor_apply_styling_functions.py
+++ b/src/editor_apply_styling_functions.py
@@ -42,7 +42,7 @@ def my_wrap_helper(editor, beforeAfter):
     # editor.web.eval(f"wrap('{before}', '{after}');")
 
     def find_escape_seq(match):
-        return escape_seqs[match.group(1)](editor, match.group(0)) if match.group(1) in escape_seqs else match.group(0)
+        return escape_seqs[match.group(1)](editor, match) if match.group(1) in escape_seqs else match.group(0)
 
     before_expanded = re.sub(r'%(.)', find_escape_seq, before)
     after_expanded = re.sub(r'%(.)', find_escape_seq, after)

--- a/src/text_wrap_escape_sequences.py
+++ b/src/text_wrap_escape_sequences.py
@@ -1,0 +1,32 @@
+import re
+
+def get_base_top(editor, text):
+    matches = []
+    query = re.sub(r'%.', r'\\d+', re.escape(text))
+
+    for name, item in editor.note.items():
+        matches.extend(re.findall(query, item))
+
+    values = [0]
+    values.extend([int(x) for x in matches])
+
+    top = max(values)
+    return top
+
+def get_top_index(editor, text):
+    base_top = get_base_top(editor, text)
+    top = base_top + 1 if base_top == 0 else base_top
+
+    return str(top)
+
+def incremented_index(editor, text):
+    base_top = get_base_top(editor, text)
+    top = base_top + 1
+
+    return str(top)
+
+escape_seqs = {
+    '%': lambda _editor, _text: '%',
+    't': get_top_index,
+    'i': incremented_index,
+}

--- a/src/text_wrap_escape_sequences.py
+++ b/src/text_wrap_escape_sequences.py
@@ -1,8 +1,8 @@
 import re
 
-def get_base_top(editor, text):
+def get_base_top(editor, match):
     matches = []
-    query = re.sub(r'%.', r'\\d+', re.escape(text))
+    query = re.escape(match.string[:match.start()]) + r'(\d+)' + re.escape(match.string[match.end():])
 
     for name, item in editor.note.items():
         matches.extend(re.findall(query, item))
@@ -13,20 +13,20 @@ def get_base_top(editor, text):
     top = max(values)
     return top
 
-def get_top_index(editor, text):
-    base_top = get_base_top(editor, text)
+def get_top_index(editor, match):
+    base_top = get_base_top(editor, match)
     top = base_top + 1 if base_top == 0 else base_top
 
     return str(top)
 
-def incremented_index(editor, text):
-    base_top = get_base_top(editor, text)
+def incremented_index(editor, match):
+    base_top = get_base_top(editor, match)
     top = base_top + 1
 
     return str(top)
 
 escape_seqs = {
-    '%': lambda _editor, _text: '%',
+    '%': lambda _editor, _match: '%',
     't': get_top_index,
     'i': incremented_index,
 }


### PR DESCRIPTION
This implements a new mechanism for text wrappers.

Using escape sequences it allows you to mimic the built-in cloze shortcuts.
Escape sequences start with a percentage sign '%'

Best way to show it is with an example:
Having before set to `{{c%i::`, and after to `}}`, makes a text wrapper that mimics the built-in Ctrl-Shift-C cloze shortcut (think of `%i` as _increment_)

Having before set to `{{c%t::`, and after to `}}`, makes a text wrapper that mimics the built-in Ctrl-Alt-Shift-C cloze shortcut (think of `%t` as _top_)

This allows for many more shortcuts, if anybody can think of something useful.
This would also need some documenting: I'll leave it up to you to decide where to do it, but I'd gladly do it myself.