### PR TITLE
Add find_matching_field variants

### DIFF
--- a/src/text_wrap_escape_sequences.py
+++ b/src/text_wrap_escape_sequences.py
@@ -25,8 +25,29 @@ def incremented_index(editor, match):
 
     return str(top)
 
+def fill_matching_field(indexer):
+    def get_value(editor, match):
+        current_index = indexer(editor, match)
+
+        for index, (name, item) in enumerate(editor.note.items()):
+            match = re.search(r'\d+$', name)
+
+            if match and match[0] == current_index and len(item) == 0:
+                js = (
+                    f'pycmd("key:{index}:{editor.note.id}:active");'
+                    f'document.querySelector("#f{index}").innerHTML = "active";'
+                )
+
+                editor.web.eval(js)
+
+        return current_index
+
+    return get_value
+
 escape_seqs = {
     '%': lambda _editor, _match: '%',
     't': get_top_index,
+    'u': fill_matching_field(get_top_index),
     'i': incremented_index,
+    'j': fill_matching_field(incremented_index),
 }


### PR DESCRIPTION
These work similiar to the existing top_index and incremented_index, except that, in the case there is a field, which ends in the same number as that index, and this field is empty, this field is filled with the word "active".

E.g. Having a text wrapper "{{c%j::", and "}}", and using it in the editor, will first wrap with "{{c1::" and "}}".
Additionally, it will also fill any empty field, that ends with the number "1" (but not e.g. "11") with the word "active".
This might seem weirdly specific, but it's terribly useful for the use in Set Randomizer, and more importantly, my new project.