### PR TITLE
Allow overwriting built-in (or defined by other add-ons) shortcuts

### DIFF
--- a/src/confdialog_Helpers.py
+++ b/src/confdialog_Helpers.py
@@ -52,12 +52,12 @@ class HotkeySelect(QDialog):
     def accept(self):
         self.hotkey = ""
         if self.dialog.cb_ctrl.isChecked():
-            self.hotkey += "ctrl+"
+            self.hotkey += "Ctrl+"
         if self.dialog.cb_shift.isChecked():
-            self.hotkey += "shift+"
+            self.hotkey += "Shift+"
         if self.dialog.cb_alt.isChecked():
-            self.hotkey += "alt+"
+            self.hotkey += "Alt+"
         if self.dialog.cb_metasuper.isChecked():
-            self.hotkey += "meta+"
-        self.hotkey += self.dialog.le_key.text()
+            self.hotkey += "Meta+"
+        self.hotkey += self.dialog.le_key.text().upper()
         QDialog.accept(self)

--- a/src/shortcuts_buttons.py
+++ b/src/shortcuts_buttons.py
@@ -47,7 +47,13 @@ def SetupShortcuts(cuts, editor):
     for e in config['v3']:
         if e.get("Hotkey", False):  # and not config["v2_show_in_contextmenu"]:
             func = editor.mycategories[e['Category']]
+
+            # remove already existing shortcuts first
+            for match in filter(lambda v: v[0] == e['Hotkey'], cuts):
+                cuts.remove(match)
+
             cuts.append((e["Hotkey"], lambda s=e["Setting"], f=func: f(editor, s)))
+
     scut = config.get("v2_key_styling_undo")
     if scut:
         cuts.append((scut, lambda e=editor: classes_addon_rangy_remove_all(e)))


### PR DESCRIPTION
For this to take effect on, the user first has to open the hotkey dialog. I think that's an acceptable sacrifice.