### PR TITLE
Avoid putting mycategories on the Editor class + Rename to apply_categories

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,7 +84,6 @@ from .config_var import getconfig
 from .css_for_webviews import create_css_for_webviews_from_config
 from .contextmenu import add_to_context
 from .defaultconfig import defaultconfig
-from .editor_apply_styling_functions import setmycategories
 from . import editor_set_css_js_for_webview
 from .shortcuts_buttons import setupButtons, SetupShortcuts
 from .vars import (
@@ -256,7 +255,6 @@ action.triggered.connect(onMySettings)
 
 profile_did_open.append(load_conf_dict)
 profile_did_open.append(contextmenu)
-profile_did_open.append(lambda: setmycategories(Editor))
 profile_will_close.append(save_conf_dict)
 
 editor_did_init_buttons.append(setupButtons)

--- a/src/contextmenu.py
+++ b/src/contextmenu.py
@@ -13,7 +13,7 @@ from aqt import mw
 from aqt.editor import Editor, EditorWebView
 
 from .config_var import getconfig
-from .editor_apply_styling_functions import classes_addon_rangy_remove_all
+from .editor_rangy_helpers import classes_addon_rangy_remove_all
 
 
 def co_my_highlight_helper(view, category, setting):

--- a/src/contextmenu.py
+++ b/src/contextmenu.py
@@ -14,10 +14,11 @@ from aqt.editor import Editor, EditorWebView
 
 from .config_var import getconfig
 from .editor_rangy_helpers import classes_addon_rangy_remove_all
+from .editor_apply_categories import apply_categories
 
 
 def co_my_highlight_helper(view, category, setting):
-    func = view.editor.mycategories[category]
+    func = apply_categories[category]
     func(view.editor, setting)
 
 

--- a/src/editor_apply_categories.py
+++ b/src/editor_apply_categories.py
@@ -19,22 +19,7 @@ from aqt.editor import Editor
 
 from .config_var import getconfig
 from .vars import unique_string
-
 from .text_wrap_escape_sequences import escape_seqs
-
-def setmycategories(editor):
-    editor.mycategories = {
-        "class (other)": editor.my_apply_span_class,
-        "class (other), wrapped in div": editor.my_wrap_in_class,
-        "style (inline)": editor.my_apply_style,
-        "Backcolor (inline)": editor.setBackcolor,
-        "Backcolor (via class)": editor.my_apply_span_class,
-        "Forecolor (inline)": editor.setForecolor,
-        "Forecolor (via class)": editor.my_apply_span_class,
-        "font size (via class)": editor.my_apply_span_class,
-        "text wrapper": editor.my_wrap_helper,
-    }
-
 
 def my_wrap_helper(editor, beforeAfter):
     before, after = beforeAfter.split(unique_string)
@@ -47,7 +32,6 @@ def my_wrap_helper(editor, beforeAfter):
     after_expanded = re.sub(r'%(.)', find_escape_seq, after)
 
     editor.web.eval(f"wrap({json.dumps(before_expanded)}, {json.dumps(after_expanded)});")
-Editor.my_wrap_helper = my_wrap_helper
 
 
 def setBackcolor(editor, color):
@@ -73,12 +57,10 @@ def setBackcolor(editor, color):
                 matches[i].removeAttribute("class");
             }
         """)
-Editor.setBackcolor = setBackcolor
 
 
 def setForecolor(editor, color):
     editor.web.eval("setFormat('forecolor', '%s')" % color)
-Editor.setForecolor = setForecolor
 
 
 def my_apply_style(editor, style):
@@ -101,13 +83,11 @@ def my_apply_style(editor, style):
             }
     """.replace("NEWSTYLE", style)
     editor.web.eval(js)
-Editor.my_apply_style = my_apply_style
 
 
 def my_wrap_in_class(editor, _class):
     js = f"classes_addon_wrap_helper('{_class}');"
     editor.web.eval(js)
-Editor.my_wrap_in_class = my_wrap_in_class
 
 
 def my_apply_span_class(editor, _class):
@@ -142,8 +122,6 @@ else {
 
 
 
-    
-    
     '''
     TODO: maybe only load rangy when command is called the first time?
 some js 
@@ -167,4 +145,16 @@ P: I'm losing focus when loading rangy: I use  focusField(0); in my "$(document)
         if e["Category"] == "class (other)" and e["Setting"] == _class and e.get("surround_with_div_tag"):
             editor.web.eval("classes_addon_wrap_helper();")
             break
-Editor.my_apply_span_class = my_apply_span_class
+
+
+apply_categories = {
+    "class (other)": my_apply_span_class,
+    "class (other), wrapped in div": my_wrap_in_class,
+    "style (inline)": my_apply_style,
+    "Backcolor (inline)": setBackcolor,
+    "Backcolor (via class)": my_apply_span_class,
+    "Forecolor (inline)": setForecolor,
+    "Forecolor (via class)": my_apply_span_class,
+    "font size (via class)": my_apply_span_class,
+    "text wrapper": my_wrap_helper,
+}

--- a/src/editor_apply_styling_functions.py
+++ b/src/editor_apply_styling_functions.py
@@ -168,20 +168,3 @@ P: I'm losing focus when loading rangy: I use  focusField(0); in my "$(document)
             editor.web.eval("classes_addon_wrap_helper();")
             break
 Editor.my_apply_span_class = my_apply_span_class
-
-
-def classes_addon_rangy_remove_all(editor):
-    # this only works on stuff rangy has highlighted before: so it doesn't help in the browser.
-    js = """
-Object.values(dict).forEach(function (item, index) {
-    item.removeAllHighlights();
-    console.log(item);
-});
-"""
-    # TODO
-    #js = """classes_addon__remove_classes_from_selection();"""
-    #editor.web.eval(js)
-    
-    # at least I can undo the following (which is arguably more important than keeping other formatting)
-    text = editor.web.selectedText()
-    editor.web.eval("setFormat('inserthtml', %s);" % json.dumps(text))

--- a/src/editor_rangy_helpers.py
+++ b/src/editor_rangy_helpers.py
@@ -1,0 +1,17 @@
+import json
+
+def classes_addon_rangy_remove_all(editor):
+    # this only works on stuff rangy has highlighted before: so it doesn't help in the browser.
+    js = """
+Object.values(dict).forEach(function (item, index) {
+    item.removeAllHighlights();
+    console.log(item);
+});
+"""
+    # TODO
+    #js = """classes_addon__remove_classes_from_selection();"""
+    #editor.web.eval(js)
+
+    # at least I can undo the following (which is arguably more important than keeping other formatting)
+    text = editor.web.selectedText()
+    editor.web.eval("setFormat('inserthtml', %s);" % json.dumps(text))

--- a/src/menu.py
+++ b/src/menu.py
@@ -27,10 +27,11 @@ from .colors import hex_to_rgb_string
 from .config_var import getconfig
 from .contextmenu import co_hex_to_rgb
 from .editor_rangy_helpers import classes_addon_rangy_remove_all
+from .editor_apply_categories import apply_categories
 
 
 def my_highlight_helper(editor, category, setting):
-    func = editor.mycategories[category]
+    func = apply_categories[category]
     func(editor, setting)
 Editor.my_highlight_helper = my_highlight_helper
 

--- a/src/menu.py
+++ b/src/menu.py
@@ -26,7 +26,7 @@ from aqt.editor import Editor
 from .colors import hex_to_rgb_string
 from .config_var import getconfig
 from .contextmenu import co_hex_to_rgb
-from .editor_apply_styling_functions import classes_addon_rangy_remove_all
+from .editor_rangy_helpers import classes_addon_rangy_remove_all
 
 
 def my_highlight_helper(editor, category, setting):

--- a/src/shortcuts_buttons.py
+++ b/src/shortcuts_buttons.py
@@ -19,6 +19,7 @@ from .config_var import getconfig
 from .menu import additional_menu_basic, additional_menu_styled
 from .vars import iconfolder
 from .editor_rangy_helpers import classes_addon_rangy_remove_all
+from .editor_apply_categories import apply_categories
 
 
 def makethisbutton(editor, e, func):
@@ -46,7 +47,7 @@ def SetupShortcuts(cuts, editor):
     config = getconfig()
     for e in config['v3']:
         if e.get("Hotkey", False):  # and not config["v2_show_in_contextmenu"]:
-            func = editor.mycategories[e['Category']]
+            func = apply_categories[e['Category']]
 
             # remove already existing shortcuts first
             for match in filter(lambda v: v[0] == e['Hotkey'], cuts):
@@ -64,7 +65,7 @@ def setupButtons(buttons, editor):
     for e in config['v3']:
         # check if extrabutton_show is set and if True:
         if e.get('extrabutton_show', False):
-            func = editor.mycategories[e['Category']]
+            func = apply_categories[e['Category']]
             buttons.append(makethisbutton(editor, e, func))
 
     # collapsible menu

--- a/src/shortcuts_buttons.py
+++ b/src/shortcuts_buttons.py
@@ -18,7 +18,7 @@ from aqt.utils import showInfo
 from .config_var import getconfig
 from .menu import additional_menu_basic, additional_menu_styled
 from .vars import iconfolder
-from .editor_apply_styling_functions import classes_addon_rangy_remove_all
+from .editor_rangy_helpers import classes_addon_rangy_remove_all
 
 
 def makethisbutton(editor, e, func):


### PR DESCRIPTION
This is to make the dependencies within the addon a bit clearer.
It also avoids one hook call (setmycategories).

Note: If you merge my other PR, this will probably become unmergeable (they both affect hooks, I'll update this one then).