### PR TITLE
Allow web imports to work from any directory name

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -84,7 +84,7 @@ from .config_var import getconfig
 from .css_for_webviews import create_css_for_webviews_from_config
 from .contextmenu import add_to_context
 from .defaultconfig import defaultconfig
-from . import editor_set_css_js_for_webview
+from .editor_set_css_js_for_webview import set_css_js_for_webview
 from .shortcuts_buttons import setupButtons, SetupShortcuts
 from .vars import (
     addonname,
@@ -252,6 +252,7 @@ action.setText(f"Adjust config for {addonname}")
 mw.form.menuTools.addAction(action)
 action.triggered.connect(onMySettings)
 
+set_css_js_for_webview()
 
 profile_did_open.append(load_conf_dict)
 profile_did_open.append(contextmenu)

--- a/src/editor_set_css_js_for_webview.py
+++ b/src/editor_set_css_js_for_webview.py
@@ -3,9 +3,12 @@
 
 import os
 
-from aqt import gui_hooks
 from aqt import mw
 from aqt.editor import Editor
+from aqt.gui_hooks import (
+    webview_will_set_content,
+    editor_did_init,
+)
 
 from .vars import (
     addon_folder_name,
@@ -43,13 +46,11 @@ def rangy_higlighters_for_each_class():
 def append_js_to_Editor(web_content, context):
     if isinstance(context, Editor):
         web_content.head += f"""\n<script>\n{rangy__create_global_variables_for_later_use()}\n</script>\n"""
-gui_hooks.webview_will_set_content.append(append_js_to_Editor)
 
 
 def append_css_to_Editor(web_content, context):
     if isinstance(context, Editor):
         web_content.head += f"""\n<style>\n{create_css_for_webviews_from_config()}\n</style>\n"""
-gui_hooks.webview_will_set_content.append(append_css_to_Editor)
 
 
 def js_inserter(self):
@@ -132,12 +133,12 @@ $(document).ready(function(){
     (async () => {
         console.log('rangy loaded by classes_addon');
 
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-core.js");
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-classapplier.js");
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-serializer.js");
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-textrange.js");
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-selectionsaverestore.js");
-        await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-highlighter.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-core.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-classapplier.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-serializer.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-textrange.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-selectionsaverestore.js");
+        await injectScript("http://127.0.0.1:PORTPORT/_addons/NAMENAME/web/rangy-highlighter.js");
 
         rangy.init();
         HIGHLIGHTERS
@@ -148,34 +149,12 @@ $(document).ready(function(){
 
 
 """.replace("PORTPORT", str(mw.mediaServer.getPort()))\
+   .replace("NAMENAME", __name__.split('.', 1)[0])\
    .replace("HIGHLIGHTERS", rangy_higlighters_for_each_class())
     self.web.eval(jsstring)
-gui_hooks.editor_did_init.append(js_inserter)
 
 
-
-"""
-if (typeof rangy === 'undefined') {
-    $(document).ready(function(){
-        (async () => {
-            console.log('rangy loaded by classes_addon');            
-
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-core.js");
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-classapplier.js");
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-serializer.js");
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-textrange.js");
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-selectionsaverestore.js");
-            await injectScript("http://127.0.0.1:PORTPORT/_addons/1899278645/web/rangy-highlighter.js");
-
-            rangy.init();
-            HIGHLIGHTERS
-            hbir_init(); // half-baked incremental reading addon
-            focusField(0);
-        })();
-    });
-}
-else {
-            HIGHLIGHTERS
-            focusField(0); 
-}
-"""
+def set_css_js_for_webview():
+    webview_will_set_content.append(append_js_to_Editor)
+    webview_will_set_content.append(append_css_to_Editor)
+    editor_did_init.append(js_inserter)


### PR DESCRIPTION
This avoids hardcoding the Ankiweb ID, and rather use the subcomponent of __name__ (which happens to be the ankiweb id, when you install it from ankiweb, but not when you link it, which is what I do).

This will help me also look into rangy issues in the future.

Additionally, I avoided putting the commands on the file scope, which gives the file a bit more structure.